### PR TITLE
Perliminary work for animation visualization in viewport

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "third_party/ImGuizmo"]
 	path = third_party/ImGuizmo
 	url = https://github.com/CedricGuillemet/ImGuizmo.git
+[submodule "third_party/glm"]
+	path = third_party/glm
+	url = https://github.com/g-truc/glm.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ list(APPEND UI_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/third_party/imgui/imgui_draw.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/third_party/imgui/examples/imgui_impl_glfw.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/third_party/imgui/examples/imgui_impl_opengl2.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/third_party/imgui/imgui_demo.cpp
     )
 
 list(APPEND UI_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,10 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third_party/glfw)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/glfw/include)
 list(APPEND EXT_LIBRARIES glfw)
 
+
+# [glm]
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/glm)
+
 add_executable(${BUILD_TARGET} ${SOURCES} ${UI_SOURCES})
 
 target_link_libraries(

--- a/src/main.cc
+++ b/src/main.cc
@@ -4,27 +4,25 @@
 #include <iostream>
 #include <vector>
 
+// For OpenGL, we always include loader library first
+#include "glad/include/glad/glad.h"
+
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Weverything"
 #endif
 
-#include "cxxopts.hpp"
-
 #include "ImCurveEdit.h"
 #include "ImSequencer.h"
+#include "cxxopts.hpp"
 #include "imgui.h"
 #include "imgui_internal.h"
 
 // imgui
+#include "GLFW/glfw3.h"
+#include "animation-sequencer.inc.h"
 #include "examples/imgui_impl_glfw.h"
 #include "examples/imgui_impl_opengl2.h"
-
-#include "glad/include/glad/glad.h"
-
-#include "GLFW/glfw3.h"
-
-#include "animation-sequencer.inc.h"
 
 #ifdef __clang__
 #pragma clang diagnostic pop
@@ -238,8 +236,8 @@ static void animation_window(const tinygltf::Model &model) {
   ImGui::End();
 }
 
-static bool BuildAnimationSequencer(const tinygltf::Model &model, gltf_insight::AnimSequence *seq)
-{
+static bool BuildAnimationSequencer(const tinygltf::Model &model,
+                                    gltf_insight::AnimSequence *seq) {
   return true;
 }
 
@@ -415,8 +413,8 @@ int main(int argc, char **argv) {
               ImSequencer::SEQUENCER_DEL | ImSequencer::SEQUENCER_COPYPASTE |
               ImSequencer::SEQUENCER_CHANGE_FRAME);
 #else
-      Sequencer(
-          &mySequence, &currentFrame, &expanded, &selectedEntry, &firstFrame, 0);
+      Sequencer(&mySequence, &currentFrame, &expanded, &selectedEntry,
+                &firstFrame, 0);
 #endif
       // add a UI to edit that particular item
       if (selectedEntry != -1) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -358,6 +358,7 @@ int main(int argc, char **argv) {
   mySequence.myItems.push_back(
       gltf_insight::AnimSequence::AnimSequenceItem{4, 90, 99, false});
 
+  bool show_imgui_demo = false;
   // Main loop
   while (!glfwWindowShouldClose(window)) {
     // Poll and handle events (inputs, window resize, etc.)
@@ -382,6 +383,9 @@ int main(int argc, char **argv) {
 
       ImGui::Text("This is some useful text.");  // Display some text (you can
                                                  // use a format strings too)
+
+      ImGui::Checkbox("Show ImGui Demo Window?", &show_imgui_demo);
+      if (show_imgui_demo) ImGui::ShowDemoWindow(&show_imgui_demo);
 
       ImGui::End();
     }

--- a/src/main.cc
+++ b/src/main.cc
@@ -119,7 +119,7 @@ static void animation_window(const tinygltf::Model &model) {
     if (sampler_names.empty()) {
       ImGui::Text("??? no samplers in animation.");
     } else {
-      int sampler_idx = 0;
+      static int sampler_idx = 0;
       ImGuiCombo("samplers", &sampler_idx, sampler_names);
 
       const tinygltf::AnimationSampler &sampler =
@@ -170,7 +170,7 @@ static void animation_window(const tinygltf::Model &model) {
     if (channel_names.empty()) {
       ImGui::Text("??? no channels in animation.");
     } else {
-      int channel_idx = 0;
+      static int channel_idx = 0;
       ImGuiCombo("channels", &channel_idx, channel_names);
 
       const tinygltf::AnimationChannel &channel =
@@ -195,7 +195,7 @@ static void animation_window(const tinygltf::Model &model) {
             ImGui::Text("%d : %f", k, value);
           }
         }
-      } else if (channel.target_path.compare("translate") == 0) {
+      } else if (channel.target_path.compare("translation") == 0) {
         for (int k = 0; k < count; k++) {
           float xyz[3];
           if (tinygltf::util::DecodeTranslationAnimationValue(

--- a/src/main.cc
+++ b/src/main.cc
@@ -78,6 +78,74 @@ static void mouseButtonCallback(int button, int state, float x, float y) {
     retturn
 #endif
 
+static int find_mesh_with_node_in_children(const tinygltf::Model &model,
+                                           int root) {
+  const auto &root_node = model.nodes[root];
+  if (root_node.mesh >= 0) return root;
+
+  for (auto child : root_node.children) {
+    const auto result = find_mesh_with_node_in_children(model, child);
+    if (result > 0 && model.nodes[result].mesh >= 0) return result;
+  }
+
+  return -1;
+}
+
+static int find_main_mesh_node(const tinygltf::Model &model) {
+  const auto &node_list =
+      model.scenes[model.defaultScene >= 0 ? model.defaultScene : 0].nodes;
+
+  for (auto node : node_list) {
+    const auto mesh_node = find_mesh_with_node_in_children(model, node);
+    if (mesh_node >= 0) return mesh_node;
+  }
+
+  return -1;
+}
+
+static void describe_node_topology(const tinygltf::Model &model,
+                                   int node_index) {
+  std::string node_desc = "node [" + std::to_string(node_index) + "]";
+  if (ImGui::TreeNode(node_desc.c_str())) {
+    const auto &node = model.nodes[node_index];
+    if (!node.name.empty()) ImGui::Text("name [%s]", node.name.c_str());
+
+    for (auto child : node.children) {
+      describe_node_topology(model, child);
+    }
+
+    ImGui::TreePop();
+  }
+}
+static void model_info_window(const tinygltf::Model &model) {
+  // TODO also cache info found here
+  if (ImGui::Begin("Model information")) {
+    const auto main_node_index = find_main_mesh_node(model);
+    if (main_node_index < 0) {
+      ImGui::Text("Could not find a node with a mesh in your glTF file!");
+      return;
+    }
+
+    ImGui::Text("Main node with a mesh [%d]");
+    const auto &main_node = model.nodes[main_node_index];
+
+    if (main_node.skin >= 0) {
+      // mesh.weights
+      ImGui::Text("Main mesh uses skin [%d]", main_node.skin);
+      const auto &skin = model.skins[main_node.skin];
+      ImGui::Text("Skin [%d] skeleton root node [%d]", main_node.skin,
+                  skin.skeleton);
+      ImGui::Text("Skin joint count [%d]", skin.joints.size());
+      if (ImGui::CollapsingHeader("Skeleton topology"))
+        describe_node_topology(model, skin.skeleton);
+    }
+
+    // TODO check if the found node with a mesh has morph targets, and
+    // describe them in this window here
+  }
+  ImGui::End();
+}
+
 static void animation_window(const tinygltf::Model &model) {
   // TODO(syoyo): Cache values
 
@@ -100,61 +168,10 @@ static void animation_window(const tinygltf::Model &model) {
     animation_names.push_back(name);
   }
 
-  int idx = 0;
+  static int idx = 0;
   ImGuiCombo("animations", &idx, animation_names);
 
   const tinygltf::Animation &animation = model.animations[size_t(idx)];
-
-  //
-  // samplers
-  //
-  if (ImGui::TreeNode("samplers")) {
-    std::vector<std::string> sampler_names;
-
-    for (size_t i = 0; i < animation.samplers.size(); i++) {
-      std::string name = "sampler_" + std::to_string(i);
-      sampler_names.push_back(name);
-    }
-
-    if (sampler_names.empty()) {
-      ImGui::Text("??? no samplers in animation.");
-    } else {
-      static int sampler_idx = 0;
-      ImGuiCombo("samplers", &sampler_idx, sampler_names);
-
-      const tinygltf::AnimationSampler &sampler =
-          animation.samplers[sampler_idx];
-
-      ImGui::Text("input  [%d]", sampler.input);
-      ImGui::Text("output [%d]", sampler.output);
-
-      float min_v, max_v;
-      if (tinygltf::util::GetAnimationSamplerInputMinMax(sampler, model, &min_v,
-                                                         &max_v)) {
-        ImGui::Text("Keyframe range : %f, %f [secs]", min_v, max_v);
-
-        int count =
-            tinygltf::util::GetAnimationSamplerInputCount(sampler, model);
-        ImGui::Text("# of key frames : %d", count);
-
-        const tinygltf::Accessor &accessor = model.accessors[sampler.input];
-        for (int k = 0; k < count; k++) {
-          float value;
-          if (tinygltf::util::DecodeScalarAnimationValue(size_t(k), accessor,
-                                                         model, &value)) {
-            // TODO(syoyo): Use table.
-            ImGui::Text("%d : %f", k, value);
-          }
-        }
-
-      } else {
-        ImGui::TextColored(ImVec4(0.9f, 0.2f, 0.1f, 1.0f),
-                           "input accessor must have min/max property");
-      }
-    }
-
-    ImGui::TreePop();
-  }
 
   //
   // channels
@@ -182,51 +199,186 @@ static void animation_window(const tinygltf::Model &model) {
 
       const tinygltf::AnimationSampler &sampler =
           animation.samplers[channel.sampler];
+      ImGui::Text("interpolation mode [%s]", sampler.interpolation.c_str());
+
       const tinygltf::Accessor &accessor = model.accessors[sampler.output];
       int count =
           tinygltf::util::GetAnimationSamplerOutputCount(sampler, model);
 
       if (channel.target_path.compare("weights") == 0) {
+        ImGui::Columns(2);
+        ImGui::Separator();
+        ImGui::Text("Frame");
+        ImGui::NextColumn();
+        ImGui::Text("Weight Value");
+        ImGui::NextColumn();
+        ImGui::Separator();
         for (int k = 0; k < count; k++) {
           float value;
           if (tinygltf::util::DecodeScalarAnimationValue(size_t(k), accessor,
                                                          model, &value)) {
-            // TODO(syoyo): Use table.
-            ImGui::Text("%d : %f", k, value);
+            ImGui::Text("%d", k);
+            ImGui::NextColumn();
+            ImGui::Text("%f", value);
+            ImGui::NextColumn();
+            ImGui::Separator();
           }
         }
+        ImGui::Columns();
       } else if (channel.target_path.compare("translation") == 0) {
+        ImGui::Columns(4);
+        ImGui::Separator();
+        ImGui::Text("Frame");
+        ImGui::NextColumn();
+        ImGui::Text("X");
+        ImGui::NextColumn();
+        ImGui::Text("Y");
+        ImGui::NextColumn();
+        ImGui::Text("Z");
+        ImGui::NextColumn();
+        ImGui::Separator();
         for (int k = 0; k < count; k++) {
           float xyz[3];
           if (tinygltf::util::DecodeTranslationAnimationValue(
                   size_t(k), accessor, model, xyz)) {
-            // TODO(syoyo): Use table.
-            ImGui::Text("%d : (%f, %f, %f)", k, xyz[0], xyz[1], xyz[2]);
+            ImGui::Text("%d", k);
+            ImGui::NextColumn();
+            ImGui::Text("%f", xyz[0]);
+            ImGui::NextColumn();
+            ImGui::Text("%f", xyz[1]);
+            ImGui::NextColumn();
+            ImGui::Text("%f", xyz[2]);
+            ImGui::NextColumn();
+            ImGui::Separator();
           }
         }
+        ImGui::Columns();
       } else if (channel.target_path.compare("scale") == 0) {
+        ImGui::Columns(4);
+        ImGui::Separator();
+        ImGui::Text("Frame");
+        ImGui::NextColumn();
+        ImGui::Text("X");
+        ImGui::NextColumn();
+        ImGui::Text("Y");
+        ImGui::NextColumn();
+        ImGui::Text("Z");
+        ImGui::NextColumn();
+        ImGui::Separator();
         for (int k = 0; k < count; k++) {
           float xyz[3];
           if (tinygltf::util::DecodeScaleAnimationValue(size_t(k), accessor,
                                                         model, xyz)) {
-            // TODO(syoyo): Use table.
-            ImGui::Text("%d : (%f, %f, %f)", k, xyz[0], xyz[1], xyz[2]);
+            ImGui::Text("%d", k);
+            ImGui::NextColumn();
+            ImGui::Text("%f", xyz[0]);
+            ImGui::NextColumn();
+            ImGui::Text("%f", xyz[1]);
+            ImGui::NextColumn();
+            ImGui::Text("%f", xyz[2]);
+            ImGui::NextColumn();
+            ImGui::Separator();
           }
         }
+        ImGui::Columns();
       } else if (channel.target_path.compare("rotation") == 0) {
+        ImGui::Columns(5);
+        ImGui::Separator();
+        ImGui::Text("Frame");
+        ImGui::NextColumn();
+        ImGui::Text("X");
+        ImGui::NextColumn();
+        ImGui::Text("Y");
+        ImGui::NextColumn();
+        ImGui::Text("Z");
+        ImGui::NextColumn();
+        ImGui::Text("W");
+        ImGui::NextColumn();
+        ImGui::Separator();
         for (int k = 0; k < count; k++) {
           float xyzw[4];
           if (tinygltf::util::DecodeRotationAnimationValue(size_t(k), accessor,
                                                            model, xyzw)) {
-            // TODO(syoyo): Use table.
-            ImGui::Text("%d : (%f, %f, %f, %f)", k, xyzw[0], xyzw[1], xyzw[2],
-                        xyzw[3]);
+            ImGui::Text("%d", k);
+            ImGui::NextColumn();
+            ImGui::Text("%f", xyzw[0]);
+            ImGui::NextColumn();
+            ImGui::Text("%f", xyzw[1]);
+            ImGui::NextColumn();
+            ImGui::Text("%f", xyzw[2]);
+            ImGui::NextColumn();
+            ImGui::Text("%f", xyzw[3]);
+            ImGui::NextColumn();
+            ImGui::Separator();
           }
         }
+        ImGui::Columns();
       } else {
         ImGui::TextColored(ImVec4(0.8f, 0.2f, 0.1f, 1.0f),
                            "??? Unknown target path name [%s]",
                            channel.target_path.c_str());
+      }
+    }
+
+    ImGui::TreePop();
+  }
+
+  //
+  // samplers
+  //
+  if (ImGui::TreeNode("samplers")) {
+    std::vector<std::string> sampler_names;
+
+    for (size_t i = 0; i < animation.samplers.size(); i++) {
+      std::string name = "sampler_" + std::to_string(i);
+      sampler_names.push_back(name);
+    }
+
+    if (sampler_names.empty()) {
+      ImGui::Text("??? no samplers in animation.");
+    } else {
+      static int sampler_idx = 0;
+      ImGuiCombo("samplers", &sampler_idx, sampler_names);
+
+      const tinygltf::AnimationSampler &sampler =
+          animation.samplers[sampler_idx];
+
+      ImGui::Text("input  [%d]", sampler.input);
+      ImGui::Text("output [%d]", sampler.output);
+      ImGui::Text("Interpolation method [%s]", sampler.interpolation.c_str());
+
+      float min_v, max_v;
+      if (tinygltf::util::GetAnimationSamplerInputMinMax(sampler, model, &min_v,
+                                                         &max_v)) {
+        ImGui::Text("Keyframe range : %f, %f [secs]", min_v, max_v);
+
+        int count =
+            tinygltf::util::GetAnimationSamplerInputCount(sampler, model);
+        ImGui::Text("# of key frames : %d", count);
+
+        const tinygltf::Accessor &accessor = model.accessors[sampler.input];
+        ImGui::Columns(2);
+        ImGui::Text("Frame Number");
+        ImGui::NextColumn();
+        ImGui::Text("Timestamp");
+        ImGui::NextColumn();
+        ImGui::Separator();
+        for (int k = 0; k < count; k++) {
+          float value;
+          if (tinygltf::util::DecodeScalarAnimationValue(size_t(k), accessor,
+                                                         model, &value)) {
+            ImGui::Text("%d", k);
+            ImGui::NextColumn();
+            ImGui::Text("%f", value);
+            ImGui::NextColumn();
+            ImGui::Separator();
+          }
+        }
+        ImGui::Columns();
+
+      } else {
+        ImGui::TextColored(ImVec4(0.9f, 0.2f, 0.1f, 1.0f),
+                           "input accessor must have min/max property");
       }
     }
 
@@ -390,6 +542,7 @@ int main(int argc, char **argv) {
       ImGui::End();
     }
 
+    model_info_window(model);
     animation_window(model);
 
     {


### PR DESCRIPTION
Changes:
---------
- Fixed the sampler/channel/animation selector in the UI
- Present the data as tables instead of list of text
- Added a window that show all images inside the glTF
 - Added a window that shows metadata about the "main" node with a mesh attached
 - If said node has a skeleton (skin), describe the topology of nodes used to describe that skeleton in the UI
 - Added a simplistic, unshaded rendering of the object in the main viewport
 - Added ImGuizmo to manipulate the model matrix used for rendering
 - Added simplistic camera controls with the mouse

To-do:
-------

- Write some real shader loading code ( = some refactoring here)
- Add a few different fragment sharers to render UV, Normals
- Load the "Joint" properties of the vertex buffer and store that CPU-side (needed for skinning)
- Add a tree data structure to be able to compute the child<->parent relationship between nodes (for calculating skeleton pose from relative transform)
 - Draw skeleton on top of model
 - Add keyframe interpolation methods (see glTF specification)
 - even more fun stuff, but I listed enough here 
